### PR TITLE
ETH-324 Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,189 @@
 # data-union-joining-server
 
-## Development
+This is a gatekeeper HTTP server for requiring Data Union members to fulfil certain requirements in order to join a Data Union. Example use cases are limiting members to users of a certain application by requiring an application secret to be passed along with the join request, or preventing bots by requiring users to complete a CAPTCHA.
 
-### Foreword
-This project uses [`Makefile`](Makefile) instead of the usual `package.json` scripts. Firstly, this is done to ensure correct versions of Node and npm. Secondly, to allow dependencies between recipes.
+The process of joining a Data Union is generally as follows:
+- At Data Union creation time, a `joinPartAgent` Ethereum address is configured on the Data Union smart contract. The `joinPartAgent` is able to add members to the Data Union.
+- This Data Union join server is configured with the private key for the `joinPartAgent` address.
+- When a member wants to join via the Data Union application, a HTTP request is sent to this join server.
+- The join server validates the join request (by validating app secret, captcha, or whatever is needed), and then makes a blockchain transaction to add the member to the Data Union.
 
-[Nvm](https://github.com/nvm-sh/nvm#readme) is used to install Node and npm. Node version is specified in [`.nvmrc`](.nvmrc).
+Data Union builder teams can easily extend the validation logic and run their own join server. Implementing any kind of join request validation logic is possible.
 
-### Common Commands
+As an alternative to running your own customized join server, the Data Union DAO hosts a **default join server**, which also extends this base package and implements a validation logic based on application secrets.
 
-Install dependencies from package.json to get started
-```
-make npm-ci
-```
+This package can also be run as-is, in which case the join server performs only signature validation and therefore allows anyone to join a Data Union.
 
-Run unit tests
-```
-make test
-```
+## Authentication
 
-Then run Data Union Join Server
-```
-make run
-```
+The endpoints exposed by the join server expect requests to be signed with the requesting Ethereum wallet using a simple signature scheme. The details are below, however most users shouldn't need to implement the authentication from scratch, but instead simply use the [Data Union client](https://www.npmjs.com/package/@dataunions/client).
 
-Run eslint
-```
-make eslint
-```
+Requests to the join server look like this:
 
-Run eslint with fix option
 ```
-make eslint-fix
+{
+   "address": "0xf79d101E1243cbDdE02d0F49E776fA65de0122ed",
+   "request": "{\"foo\":\"bar\"}",
+   "timestamp": "2022-07-01T00:00:00.000Z",
+   "signature": "0xefde1ff335c8fb28fe9f49c87c39c21659b5ad1a6967d154c4d4ea1978f572a02c7d82f8ab5828b7550246220919594bc84361cb50a89ce74a957eefc59dd4a41b"
+}
 ```
 
-Run clean
+- `request` - the actual request as stringified JSON
+- `address` - the Ethereum address that originated the request
+- `timestamp` - timestamp of the request in ISO 8601 format. The join server will by default reject requests with timestamps more than 5 minutes off from current time
+- `signature` - a hex-encoded signature produced by signing the `request` with the private key of `address` using the Ethereum message signing (for example [`signer.signMessage()` in ethers](https://docs.ethers.io/v5/api/signer/#Signer-signMessage))
+
+Different endpoints expect different types of content in `request`. Users that extend the server can add new endpoints and submit arbitrary `request` content.
+
+## HTTP Endpoints
+
+This base package only exposes one endpoint, which is used for submitting join requests.
+
+### `/join`
+
+Expects the `request` in the wrapper object to be of form:
+
 ```
-make clean
+{
+    "dataUnion": "0x12345",
+    "chain": "polygon"
+}
 ```
 
-Run help
+or in other words, the full signed HTTP request body would be:
+
 ```
-make help
+{
+   "address": "0xabcdef",
+   "request": "{\"dataUnion\":\"0x12345\",\"chain\":\"polygon\",}",
+   "timestamp": "...",
+   "signature": "..."
+}
 ```
 
-### API
+Such a request would join `address` (`0xabcdef`) as member of the Data Union at smart contract address `0x12345`, to be found on the Polygon chain.
 
-- [NodeJS 16.x](https://nodejs.org/dist/latest-v16.x/docs/api/)
-- [Express 5.x](https://expressjs.com/en/5x/api.html)
-- [Commander.js](https://www.npmjs.com/package/commander)
-- [Ethers API 5.x](https://docs.ethers.io/v5/api/)
-- [Pino API 7.x](https://github.com/pinojs/pino/blob/master/docs/api.md)
+The join request can contain arbitrary additional fields, which are validated by passing to the server a `customJoinRequestValidator` function - see below for information about extending and customizing the server.
 
-#### Testing
-- [Mocha](https://mochajs.org/api/)
-- [Chai](https://www.chaijs.com/api/assert/)
-- [Supertest](https://www.npmjs.com/package/supertest)
+
+## Usage
+
+The most typical use case for this package is to extend the functionality of the join server by adding custom validation logic and/or additional HTTP endpoints.
+
+- Start a new node.js project for your custom join server
+- Install this base package as a dependency:
+
+```
+npm install --save @dataunions/join-server
+```
+
+- Then you can use the server in your application:
+
+```
+const { JoinServer } = require('@dataunions/JoinServer')
+
+const srv = new JoinServer({
+    // Always pass in the private key for the wallet you set as the joinPartAgent
+    privateKey: '...',
+
+    // Additional options, see below
+    ...
+})
+srv.start()
+```
+
+### Adding custom fields to join requests
+
+In many cases, you'll want to pass some additional information from the end-user app to the join server, such as CAPTCHA responses or other information used to accept the new member. In that case, the join request will have the `dataUnion` and `chain` keys plus your custom ones for which you can choose any names you want:
+
+```
+{
+    "dataUnion": "0x12345",
+    "chain": "polygon",
+    "myCustomSecret": "foo"
+}
+```
+
+To inject your custom validation logic to the join server, pass the `customJoinRequestValidator` function to the constructor. This is an async function (returns a promise) that is expected to resolve if the validation passes, or reject if it fails. For example:
+
+```
+const srv = new JoinServer({
+    ...
+    customJoinRequestValidator = async (joinRequest) => {
+        if (joinRequest.myCustomSecret !== 'foo') {
+            throw new Error('My custom secret is incorrect!')
+        }
+    },
+})
+```
+
+### Adding custom endpoints
+
+Custom endpoints (routes) can be created on the server by passing in a `customRoutes` function, which receives the `express` app instance as an argument.
+
+All requests pass through the signature validation middleware, which makes the parsed and validated content of the `request` payload available as `req.validatedRequest`.
+
+Here's a simple example of a custom endpoint `POST /hello` that reads payloads with a `message` field in them:
+
+```
+const srv = new JoinServer({
+    ...
+    customRoutes = (expressApp) => {
+        app.post('/hello', function(req, res, next) {
+            res.status(200)
+            res.set('content-type', 'application/json')
+            res.send({
+                // Fields in the request payload can be accessed via req.validatedRequest
+                message: req.validatedRequest.message,
+                // Fields in the raw request (signed wrapper) can be accessed via req.body
+                from: req.body.address,
+            })
+        })
+    },
+})
+```
+
+In the context of the signed message wrapper, the full request to this endpoint would look like this:
+
+```
+{
+   "address": "...",
+   "request": "{\"message\":\"Hi there!\"}",
+   "timestamp": "...",
+   "signature": "..."
+}
+```
+
+### Options
+
+See below for the various constructor options and their default values. At a minimum, you should pass in at least the `privateKey`.
+
+```
+new JoinServer({
+    // Hex-encoded private key for your joinPartAgent address
+    privateKey: '...', 
+
+    // HTTP port the server listens on
+    port: 5555,
+
+    // Logger (pino) level: one of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'.
+    logLevel: 'info',
+
+    // Used to validate custom fields in join requests. The default function does nothing.
+    customJoinRequestValidator: async (joinRequest) => {},
+
+    // Used to add custom routes to the HTTP server. The default function does nothing.
+    customRoutes: (expressApp) => {},
+
+    // By default public RPCs are used for each chain, but you can pass this option to override
+    customRPCs: {
+        polygon: 'https://my-custom-polygon-rpc-address',
+        gnosis: 'https://my-custom-gnosis-rpc-address',
+    }
+})
+```
+
+## Developing
+
+To learn about building and developing this software, see [developing.md](developing.md).

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Here's a simple example of a custom endpoint `POST /hello` that reads payloads w
 const srv = new JoinServer({
     ...
     customRoutes = (expressApp) => {
-        app.post('/hello', function(req, res, next) {
+        expressApp.post('/hello', function(req, res, next) {
             res.status(200)
             res.set('content-type', 'application/json')
             res.send({

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The process of joining a Data Union is generally as follows:
 
 Data Union builder teams can easily [extend](#extending) the validation logic and run their own join server. Implementing any kind of join request validation logic is possible.
 
-As an alternative to running your own customized join server, the Data Union DAO hosts a **default join server**, which also extends this base package and implements a validation logic based on application secrets stored in a database.
+As an alternative to running your own customized join server, the Data Union DAO hosts a [default join server](https://github.com/dataunions/default-join-server), which also extends this base package and implements a validation logic based on application secrets stored in a database. Forking that as a starting point may be an easier way to get started on your own customizations, or you can follow the instructions in this readme to start the customizations from scratch.
 
 This package can also be [run as-is](#running-as-is), in which case the join server performs only signature validation and therefore allows anyone to join a Data Union.
 
@@ -39,6 +39,8 @@ const srv = new JoinServer({
 })
 srv.start()
 ```
+
+That's exactly what's happening in the [default join server](https://github.com/dataunions/default-join-server). Forking that may be a faster starting point for your own customizations, or you can study this readme to start your customizations from scratch.
 
 ### Options
 

--- a/developing.md
+++ b/developing.md
@@ -1,0 +1,58 @@
+## Developing the Data Union join server
+
+This section is intended for the developers of this software, not users of this software.
+
+### Foreword
+This project uses [`Makefile`](Makefile) instead of the usual `package.json` scripts. Firstly, this is done to ensure correct versions of Node and npm. Secondly, to allow dependencies between recipes.
+
+[Nvm](https://github.com/nvm-sh/nvm#readme) is used to install Node and npm. Node version is specified in [`.nvmrc`](.nvmrc).
+
+### Common Commands
+
+Install dependencies from package.json to get started
+```
+make npm-ci
+```
+
+Run unit tests
+```
+make test
+```
+
+Then run Data Union Join Server
+```
+make run
+```
+
+Run eslint
+```
+make eslint
+```
+
+Run eslint with fix option
+```
+make eslint-fix
+```
+
+Run clean
+```
+make clean
+```
+
+Run help
+```
+make help
+```
+
+### API
+
+- [NodeJS 16.x](https://nodejs.org/dist/latest-v16.x/docs/api/)
+- [Express 5.x](https://expressjs.com/en/5x/api.html)
+- [Commander.js](https://www.npmjs.com/package/commander)
+- [Ethers API 5.x](https://docs.ethers.io/v5/api/)
+- [Pino API 7.x](https://github.com/pinojs/pino/blob/master/docs/api.md)
+
+#### Testing
+- [Mocha](https://mochajs.org/api/)
+- [Chai](https://www.chaijs.com/api/assert/)
+- [Supertest](https://www.npmjs.com/package/supertest)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "server",
-  "version": "0.0.0",
+  "name": "@dataunions/join-server",
+  "version": "0.0.1",
   "description": "",
   "main": "src/cmd/duj-srv/main.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "npm": "8.1.2"
   },
   "bin": {
-    "duj-srv": "src/cmd/duj-srv/main.js"
+    "join-server": "src/cmd/duj-srv/main.js"
   },
   "scripts": {
     "test": "mocha --recursive --check-leaks test",

--- a/src/app/JoinServer.js
+++ b/src/app/JoinServer.js
@@ -18,11 +18,21 @@ class JoinServer {
 		/**
 		 * These options are primarily intended for end users
 		 */
+		
+		// Hex-encoded private key for your joinPartAgent address
 		privateKey,
+
+		// HTTP port the server listens on
 		port = 5555,
+
+		// Logger (pino) level: one of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'.
 		logLevel = 'info',
+
+		// Used to validate custom fields in join requests. The default function does nothing.
 		customJoinRequestValidator = async (/* joinRequest */) => {},
-		customRoutes = (/*app*/) => {},
+
+		// Used to add custom routes to the HTTP server. The default function does nothing.
+		customRoutes = (/*expressApp*/) => {},
 
 		/**
 		 * These options are primarily intended for advanced use or passing in test mocks


### PR DESCRIPTION
A first pass on a README that details how this package is intended to be used. A few of the described things are not yet implemented:

- The package is not yet available as an npm package ([ETH-325](https://linear.app/streamr/issue/ETH-325/publish-base-join-server-as-npm-package))
- Passing in the `chain` key in join requests doesn't do anything yet, but is a core part of the multichain support ticket ([ETH-308](https://linear.app/streamr/issue/ETH-308/add-multi-chain-support))
- Passing in custom RPC endpoints as `customRPCs` isn't supported yet, but should be added as part of the multichain support ([ETH-308](https://linear.app/streamr/issue/ETH-308/add-multi-chain-support))

The rest of the things described in the README are already there.

I intentionally left undocumented the constructor options that are intended for advanced/mock use, only detailing in the README the ones intended for normal end users.